### PR TITLE
[MT-4505] Rename Bookmark `href` attr to `url`

### DIFF
--- a/src/format/elements/BookmarkNode.ts
+++ b/src/format/elements/BookmarkNode.ts
@@ -12,7 +12,7 @@ export enum BookmarkCardLayout {
 
 export interface BookmarkNode extends Element<typeof BookmarkNode.TYPE> {
     uuid: string;
-    href: string;
+    url: string;
     oembed: OEmbedInfo;
     layout: BookmarkCardLayout;
     show_thumbnail: boolean;


### PR DESCRIPTION
Came to this after rethinking consistentcy between `EmbedNode`, `BookmarkNode` and `VideoNode` (#3)